### PR TITLE
action activation callbacks

### DIFF
--- a/btreeviz.js
+++ b/btreeviz.js
@@ -1,6 +1,13 @@
-// Render _root_ inside the _parent_ DOM node with a viewbox width
-// of _width_.  _x0_ and _x1_ are used to determine the vertical height
-// of the tree inside the viewbox.
+/**
+ * Render _root_ inside the _parent_ DOM node with a viewbox width
+ * of _width_.  _x0_ and _x1_ are used to determine the vertical height
+ * of the tree inside the viewbox.
+ * @param {string} parent HTML element type
+ * @param {Rl} root D3 hierarchy tree root node
+ * @param {number} width 
+ * @param {number} x0 
+ * @param {number} x1 
+ */
 function renderTree(parent, root, width, x0, x1) {
     function translate(tree) {
         let x = tree.dy + tree.drag_dx,
@@ -163,24 +170,6 @@ function renderTree(parent, root, width, x0, x1) {
     });
 }
 
-/**
- * Gets friendly status
- * @param {number} status tree node status
- * @returns {string} user-friendly status string
- */
-function getFriendlyStatus(status) {
-    switch (status) {
-        case FAILED:
-            return 'Failed';
-        case SUCCESS:
-            return 'Success';
-        case RUNNING:
-            return 'Running';
-        default:
-            return 'Unknown';
-    }
-}
-
 function clamp(val, min, max) {
     if (val < min) {
         return min;
@@ -201,8 +190,8 @@ function windowSize() {
     return [x, y];
 }
 
-function showError(message) {
-    d3.select('main')
+function showError(message, parent) {
+    d3.select(parent)
             .html('')
             .append('div')
             .classed('tree-error__container', true)
@@ -214,19 +203,27 @@ function showError(message) {
 /**
  * Parses and shows the supplied tree.
  * @param {string} str behavior tree as string
+ * @param {string} parent name of hosting HTML element
+ * @returns {void}
  */
-function loadTree(str) {
+function loadTree(str, parent) {
     let tree = parse(str),
         line = tree.line;
     if (tree.error) {
-        showError(`Line ${line}: ${tree.error}`);
+        showError(`Line ${line}: ${tree.error}`, parent);
         return;
     }
 
-    showTree(tree);
+    showTree(tree, parent);
 }
 
-function showTree(tree) {
+/**
+ * Populates the page with the behavior _tree_ and condition and action control elements.
+ * @param {BehaviorTree} tree behavior tree
+ * @param {string} parent name of hosting HTML element
+ * @returns {void}
+ */
+function showTree(tree, parent) {
     let x0   = Infinity,
         x1   = -x0,
         data = d3.hierarchy(tree.root),
@@ -257,7 +254,7 @@ function showTree(tree) {
         render();
     });
 
-    d3.select('main')
+    d3.select(parent)
         .on('wheel', function() {
             let e = d3.event;
             let up = false;
@@ -285,7 +282,7 @@ function showTree(tree) {
     let conds = d3.select('#tree-conditions')
         .html('')
         .selectAll('a')
-        .data(Object.keys(tree.conditions).sort())
+        .data([...tree.conditions.keys()].sort())
         .enter()
         .append('a')
         .classed('mdl-navigation__link', true);
@@ -320,7 +317,7 @@ function showTree(tree) {
     let actions = d3.select('#tree-actions')
         .html('')
         .selectAll('a')
-        .data(Object.keys(tree.actions).sort())
+        .data([...tree.actions.keys()].sort())
         .enter()
         .append('a')
         .classed('mdl-navigation__link tree-action', true);
@@ -381,17 +378,14 @@ function showTree(tree) {
     });
 
     function render() {
-        // if (typeof (root.data.deactivate) === 'function') {
-            // let's only 'tick' trees that have not been loaded over http from a behavior tree service
-            root.data.deactivate();
-            root.data.tick();
-        // }
-        renderTree('main', root, width, x0, x1);
+        root.data.deactivate();
+        root.data.tick();
+        renderTree(parent, root, width, x0, x1);
     }
     render();
 }
 
-function main() {
+function main(parentElement) {
     let treeSelect = document.getElementById('treeFileSelect'),
         treeInput  = document.getElementById('treeFileInput');
 
@@ -401,7 +395,7 @@ function main() {
         }
         let reader = new FileReader();
         reader.onload = function(e) {
-            loadTree(e.target.result);
+            loadTree(e.target.result, parentElement);
         };
         reader.readAsText(this.files[0]);
     }, false);
@@ -424,5 +418,5 @@ function main() {
             card.style('visibility', viz);
         });
 
-    loadTree(SAMPLE_TREE);
+    loadTree(SAMPLE_TREE, parentElement);
 }

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
     .tree-help__action { font-weight: bold; }
   </style>
 </head>
-<body onload="main()">
+<body onload="main('main')">
   <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
     <header class="mdl-layout__header">
       <div class="mdl-layout__header-row">

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,12 @@
     "requires": true,
     "lockfileVersion": 1,
     "dependencies": {
+        "JSONSelect": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz",
+            "integrity": "sha1-oI7cxn6z/L6Z7WMIVTRKDPKCu40=",
+            "dev": true
+        },
         "accepts": {
             "version": "1.3.7",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -60,6 +66,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
             "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+            "dev": true
+        },
+        "augment": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/augment/-/augment-3.2.1.tgz",
+            "integrity": "sha1-7F2elFYUDvqxEQ/ds1LL5U5/sxw=",
             "dev": true
         },
         "balanced-match": {
@@ -239,6 +251,12 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
+        "colors": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+            "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+            "dev": true
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -325,6 +343,12 @@
             "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
             "dev": true
         },
+        "ebnf-parser": {
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/ebnf-parser/-/ebnf-parser-0.1.10.tgz",
+            "integrity": "sha1-zR9rpHfFY4xAyX7ZtXLbW6tdgzE=",
+            "dev": true
+        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -382,10 +406,35 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
+        "escodegen": {
+            "version": "0.0.21",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.21.tgz",
+            "integrity": "sha1-U9ZSz6EDA4gnlFilJmxf/HCcY8M=",
+            "dev": true,
+            "requires": {
+                "esprima": "~1.0.2",
+                "estraverse": "~0.0.4",
+                "source-map": ">= 0.1.2"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+                    "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+                    "dev": true
+                }
+            }
+        },
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
+        "estraverse": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz",
+            "integrity": "sha1-AaCTLf7ldGhKWYr1pnw7+bZCjbI=",
             "dev": true
         },
         "etag": {
@@ -686,6 +735,39 @@
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
         },
+        "jison": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/jison/-/jison-0.4.4.tgz",
+            "integrity": "sha1-hrA7Ze/sAHqR9JPs6r5W+QqmtDk=",
+            "dev": true,
+            "requires": {
+                "JSONSelect": "0.4.0",
+                "ebnf-parser": "0.1.x",
+                "escodegen": "0.0.21",
+                "esprima": "1.0.x",
+                "jison-lex": "0.2.x",
+                "lex-parser": "0.1.x",
+                "nomnom": "1.5.2"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+                    "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+                    "dev": true
+                }
+            }
+        },
+        "jison-lex": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/jison-lex/-/jison-lex-0.2.1.tgz",
+            "integrity": "sha1-rEuBXozOUTLrErXfz+jXB7iETf4=",
+            "dev": true,
+            "requires": {
+                "lex-parser": "0.1.x",
+                "nomnom": "1.5.2"
+            }
+        },
         "js-yaml": {
             "version": "3.13.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -695,6 +777,18 @@
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
             }
+        },
+        "lex": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/lex/-/lex-1.7.4.tgz",
+            "integrity": "sha1-M91muYCjjXemxCTXFz5vQNYCwMU=",
+            "dev": true
+        },
+        "lex-parser": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/lex-parser/-/lex-parser-0.1.4.tgz",
+            "integrity": "sha1-ZMTwJfF/1Tv7RXY/rrFvAVp0dVA=",
+            "dev": true
         },
         "locate-path": {
             "version": "3.0.0",
@@ -845,6 +939,16 @@
             "requires": {
                 "object.getownpropertydescriptors": "^2.0.3",
                 "semver": "^5.7.0"
+            }
+        },
+        "nomnom": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
+            "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
+            "dev": true,
+            "requires": {
+                "colors": "0.5.x",
+                "underscore": "1.1.x"
             }
         },
         "normalize-path": {
@@ -1006,6 +1110,18 @@
                 "picomatch": "^2.0.4"
             }
         },
+        "regex": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/regex/-/regex-0.1.1.tgz",
+            "integrity": "sha1-BYCZXRhGxTdqdiudNYuDBo0geu8=",
+            "dev": true,
+            "requires": {
+                "augment": "3.2.1",
+                "jison": "0.4.4",
+                "lex": "1.7.4",
+                "statemachines": "0.1.0"
+            }
+        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1083,11 +1199,34 @@
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
             "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
         },
+        "sorted-array": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/sorted-array/-/sorted-array-1.1.0.tgz",
+            "integrity": "sha1-YamDJeQSu5CZm0usGN/tXzVkEC0=",
+            "dev": true
+        },
+        "source-map": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+            "dev": true,
+            "optional": true
+        },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
+        },
+        "statemachines": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/statemachines/-/statemachines-0.1.0.tgz",
+            "integrity": "sha1-tUX9PYpVKA8wK4aW8ZwKEcTjOt4=",
+            "dev": true,
+            "requires": {
+                "augment": "3.2.1",
+                "sorted-array": "1.1.0"
+            }
         },
         "statuses": {
             "version": "1.5.0",
@@ -1176,6 +1315,18 @@
                 "media-typer": "0.3.0",
                 "mime-types": "~2.1.24"
             }
+        },
+        "typescript": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+            "dev": true
+        },
+        "underscore": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
+            "integrity": "sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA=",
+            "dev": true
         },
         "unpipe": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "scripts": {
-        "test": "mocha"
+        "test": "mocha",
+        "check": "tsc btree.js --allowJS --checkJS --noEmit --lib ES2015"
     },
     "dependencies": {
         "body-parser": "^1.19.0",
@@ -9,6 +10,7 @@
     },
     "devDependencies": {
         "chai": "^4.2.0",
-        "mocha": "^7.1.0"
+        "mocha": "^7.1.0",
+        "typescript": "^3.8.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
     "scripts": {
         "test": "mocha"
     },
+    "dependencies": {
+        "body-parser": "^1.19.0",
+        "cors": "^2.8.5",
+        "express": "^4.17.1"
+    },
     "devDependencies": {
         "chai": "^4.2.0",
         "mocha": "^7.1.0"

--- a/test/btree.js
+++ b/test/btree.js
@@ -2,6 +2,57 @@
 
 let btree = require('../btree').bt;
 let expect = require('chai').expect;
+let fs = require('fs');
+
+describe('README.md samples', () => {
+    it('runs all samples from README.md', () => {
+
+        let fenceStart = new RegExp(/^```(.+)$/, "gm");
+        let fenceEnd = new RegExp(/^```$/, "gm");
+
+        let readme = fs.readFileSync('./README.md', { encoding: 'utf8' });
+        /** @type {RegExpExecArray} */
+        let startMatch = null;
+        while ((startMatch = fenceStart.exec(readme)) !== null) {
+            let language = startMatch[1];
+            let fencedTextStartIdx = startMatch.index + startMatch[0].length + 1;
+            fenceEnd.lastIndex = fencedTextStartIdx;
+
+            let endMatch = fenceEnd.exec(readme);
+            if (endMatch === null) {
+                break;
+            }
+            fenceStart.lastIndex = endMatch.index + endMatch[0].length + 1;
+            let fencedText = readme.substring(fencedTextStartIdx, endMatch.index);
+            console.log(`${language}: ${fencedText}`);
+            checkSample(language, fencedText);
+        }
+
+    });
+})
+
+/**
+ * Check the code sample
+ * @param {string} language code language
+ * @param {string} sampleCode
+ */
+function checkSample(language, sampleCode) {
+    switch (language.toLowerCase()) {
+        case 'tree':
+            let tree = btree.parse(sampleCode);
+            expect(tree.root).to.be.not.null;
+            expect(tree.error, `there should be no error in tree sample ${sampleCode}`).to.be.null;
+            break;
+        case 'javascript':
+            const runSample = () => {
+                eval(sampleCode);
+            }
+            expect(runSample, `sample: ${sampleCode}`).to.not.throw();
+            break;
+        default:
+            console.warn(`Language ${language} not supported for checking.`);
+    }
+}
 
 describe('#parse', () => {
 
@@ -10,8 +61,8 @@ describe('#parse', () => {
             let tree = btree.parse(btree.SAMPLE_TREE);
             expect(tree.root).to.be.not.null;
             expect(tree.error).to.be.null;
-            expect(tree.conditions['Ghost Scared']).to.have.length(2);
-            expect(tree.actions['Avoid Ghost']).to.have.length(1);
+            expect(tree.conditions.get('Ghost Scared')).to.have.length(2);
+            expect(tree.actions.get('Avoid Ghost')).to.have.length(1);
         });
     });
 
@@ -33,7 +84,9 @@ describe('#parse', () => {
             let tree = btree.parse(`=${count}`);
             expect(tree.root).to.be.not.null;
             expect(tree.root.kind).to.be.equal(btree.PARALLEL);
-            expect(tree.root.successCount).to.be.equal(count);
+            /** @type {btree.Parallel} */
+            let actualParallel = tree.root;
+            expect(actualParallel.successCount).to.be.equal(count);
         });
 
         it('parses condition', () => {
@@ -43,7 +96,7 @@ describe('#parse', () => {
             expect(tree.root.kind).to.be.equal(btree.CONDITION);
             expect(tree.root.name).to.be.equal(conditionName);
             expect(tree.root.hasNot).to.be.equal(false);
-            expect(tree.conditions[conditionName]).to.be.deep.equal([tree.root]);
+            expect(tree.conditions.get(conditionName)).to.be.deep.equal([tree.root]);
         });
 
         it('parses negated condition', () => {
@@ -53,7 +106,7 @@ describe('#parse', () => {
             expect(tree.root.kind).to.be.equal(btree.CONDITION);
             expect(tree.root.name).to.be.equal(conditionName);
             expect(tree.root.hasNot).to.be.equal(true);
-            expect(tree.conditions[conditionName]).to.be.deep.equal([tree.root]);
+            expect(tree.conditions.get(conditionName)).to.be.deep.equal([tree.root]);
         });
 
         it('parses double-negated condition', () => {
@@ -63,7 +116,7 @@ describe('#parse', () => {
             expect(tree.root.kind).to.be.equal(btree.CONDITION);
             expect(tree.root.name).to.be.equal(conditionName);
             expect(tree.root.hasNot).to.be.equal(false);
-            expect(tree.conditions[conditionName]).to.be.deep.equal([tree.root]);
+            expect(tree.conditions.get(conditionName)).to.be.deep.equal([tree.root]);
         });
 
         it('parses action', () => {
@@ -72,7 +125,7 @@ describe('#parse', () => {
             expect(tree.root).to.be.not.null;
             expect(tree.root.kind).to.be.equal(btree.ACTION);
             expect(tree.root.name).to.be.equal(actionName);
-            expect(tree.actions[actionName]).to.be.deep.equal([tree.root]);
+            expect(tree.actions.get(actionName)).to.be.deep.equal([tree.root]);
         });
     });
 
@@ -134,6 +187,21 @@ describe('#parse', () => {
 
 describe("BehaviorTree", () => {
     describe("#fromJson", () => {
+        it('builds tre from JSON)', () => {
+            let tree = btree.BehaviorTree.fromJson(JSON.parse(`{
+                "root":{
+                    "name": "Avoid Ghost",
+                    "kind": "action",
+                    "children": null,
+                    "active": false,
+                    "wasActive": false,
+                    "nodeStatus": 2,
+                    "hasNot": false
+                }
+            }`));
+            expect(tree.root.kind).to.be.equal(btree.ACTION);
+        });
+
         it('parses sample and re-hydrates it from JSON', () => {
             let tree = btree.parse(btree.SAMPLE_TREE);
             tree.root.tick();
@@ -172,8 +240,144 @@ describe("BehaviorTree", () => {
             actualTree.root.tick();
             // then
             expect(actualTree.root.status()).equal(btree.RUNNING, "action status should be RUNNING");
-            expect(actualTree.root.active).equal(true, "action status should be 'active'");
+            expect(actualTree.root.active()).equal(true, "action status should be 'active'");
         });
+    });
+
+    describe('#tick', () => {
+        it('notify about action activation when ticked', () => {
+            let action1 = btree.action("action1");
+            let tree = new btree.BehaviorTree(action1, 0, undefined);
+            // when
+            let actualActivatedAction = null;
+            tree.onActionActivation(actionNode => actualActivatedAction = actionNode);
+            tree.root.tick();
+            // then
+            expect(tree.root.status()).equal(btree.RUNNING);
+            expect(tree.root.active()).equal(true);
+            expect(actualActivatedAction).equal(tree.root);
+        });
+
+        it('notify about action activation when ticked (in parsed tree)', () => {
+            let tree = btree.parse(`[a]`);
+            expect(tree.root.kind).to.be.equal(btree.ACTION);
+            // when
+            let actualActivatedAction = null;
+            tree.onActionActivation(actionNode => actualActivatedAction = actionNode);
+            tree.root.tick();
+            // then
+            expect(tree.root.status()).equal(btree.RUNNING);
+            expect(tree.root.active()).equal(true);
+            expect(actualActivatedAction).equal(tree.root);
+        });
+
+        it('notify about action activation when ticked (in JSON tree)', () => {
+            let tree = btree.BehaviorTree.fromJson(JSON.parse(`{
+                "root":{
+                    "name": "Avoid Ghost",
+                    "kind": "action",
+                    "children": null,
+                    "active": false,
+                    "wasActive": false,
+                    "nodeStatus": 2,
+                    "hasNot": false
+                }
+            }`));
+            expect(tree.root.kind).to.be.equal(btree.ACTION);
+            // when
+            let actualActivatedAction = null;
+            tree.onActionActivation(actionNode => actualActivatedAction = actionNode);
+            tree.root.tick();
+            // then
+            expect(tree.root.status()).equal(btree.RUNNING);
+            expect(tree.root.active()).equal(true);
+            expect(actualActivatedAction).equal(tree.root);
+        });
+
+
+        it('executes a sample parsed tree', () => {
+            let tree = btree.parse(`
+            ?
+            |   !(have hunger)
+            |   [eat]`);
+
+            // subscribe to action activation
+            tree.onActionActivation(actionNode => {
+                switch (actionNode.name) {
+                    case 'eat':
+                        console.log(btree.getFriendlyStatus(actionNode.status())); // prints 'running'
+                        if (actionNode.active()) { // in general we should check that the action is in an active branch
+                            console.log('Started eating...');
+                            // no longer hungry!
+                            tree.setConditionStatus('have hunger', btree.FAILED);
+                            console.log('Done eating...');
+                            tree.setActionStatus('eat', btree.SUCCESS);
+                        }
+                }
+            });
+            tree.root.tick();
+            
+            console.log('Initial state:');
+            console.log(btree.getFriendlyStatus(tree.root.status())); // prints 'success'
+            console.log(tree.root.active()); // prints true
+            
+            // then we get hunger
+            tree.setConditionStatus('have hunger', btree.SUCCESS);
+            let statusAfterHungerIsTrue = tree.root.tick();
+            console.log(btree.getFriendlyStatus(statusAfterHungerIsTrue)); // prints 'success', because the action was executed synchronously as part of the tick
+
+            // now 'Eating...' should be printed
+
+            // final state:
+            tree.root.tick();
+            console.log(btree.getFriendlyStatus(tree.root.status())); // prints 'success'
+        });
+
+        it('executes a sample coded tree', () => {
+
+            // define the action 'eat' implementation
+            let onEat = function (actionNode) {
+                switch (actionNode.name) {
+                    case 'eat':
+                        console.log(btree.getFriendlyStatus(actionNode.status())); // prints 'running'
+                        if (actionNode.active()) { // in general we should check that the action is in an active branch
+                            console.log('Started eating...');
+                            // no longer hungry!
+                            tree.setConditionStatus('have hunger', btree.FAILED);
+                            console.log('Done eating...');
+                            tree.setActionStatus('eat', btree.SUCCESS);
+                        }
+                }
+            };
+
+            // ?
+            // |   !(have hunger)
+            // |   [eat]`
+
+            let rootNode = btree.fallback([
+                btree.condition("have hunger", true),
+                btree.action("eat", onEat)
+            ]);
+            let tree = new btree.BehaviorTree(rootNode);
+
+            tree.root.tick();
+            
+            console.log('Initial state:');
+            console.log(btree.getFriendlyStatus(tree.root.status())); // prints 'success'
+            console.log(tree.root.active()); // prints true
+            
+            // then we get hunger
+            tree.setConditionStatus('have hunger', btree.SUCCESS);
+            let statusAfterHungerIsTrue = tree.root.tick();
+            console.log(btree.getFriendlyStatus(statusAfterHungerIsTrue)); // prints 'success', because the action was executed synchronously as part of the tick
+
+            // now 'Eating...' should be printed
+
+            // final state:
+            tree.root.tick();
+            console.log(btree.getFriendlyStatus(tree.root.status())); // prints 'success'
+        });
+
     });
 });
 
@@ -188,16 +392,39 @@ describe('#fallback', () => {
     });
 });
 
-describe('#action', () => {
-    it('runs action when ticked', () => {
-        let tree = btree.parse(`[a]`);
-        expect(tree.root.kind).to.be.equal(btree.ACTION);
-        // when
-        let activatedAction = null;
-        tree.onActionActivation(actionNode => activatedAction = actionNode);
-        tree.root.tick();
-        expect(tree.root.status()).equal(btree.RUNNING);
-        expect(tree.root.active).equal(true);
-        expect(activatedAction).equal(tree.root);
+describe('Action', () => {
+    describe('#tick', () => {
+        it('runs action when ticked', () => {
+            let action1 = btree.action("action1", actionNode => actualActivatedAction = actionNode);
+            // when
+            let actualActivatedAction = null;
+            action1.tick();
+            // then
+            expect(action1.status()).equal(btree.RUNNING);
+            expect(action1.active()).equal(true);
+            expect(action1.wasActive).equal(false);
+            expect(actualActivatedAction).deep.equal(action1);
+        });
+    });
+
+    describe('#wasActive', () => {
+        it('re-activates previously active action', () => {
+            let action1 = btree.action("action1", actionNode => actualActivatedActions.push(actionNode));
+            // when
+            let actualActivatedActions = [];
+            action1.tick();
+            // then
+            expect(action1.status()).equal(btree.RUNNING);
+            expect(action1.active()).equal(true);
+            expect(action1.wasActive).equal(false);
+            expect(actualActivatedActions).contains(action1);
+            // when .. action is finished
+            action1.setStatus(btree.FINISHED);
+            action1.deactivate(); // simulate that another tree branch became active
+            // then
+            expect(action1.status()).equal(btree.FINISHED);
+            expect(action1.active()).equal(false);
+            expect(action1.wasActive).equal(true);
+        });
     });
 });

--- a/test/btree.js
+++ b/test/btree.js
@@ -187,3 +187,17 @@ describe('#fallback', () => {
         expect(tree.root.status()).equal(btree.FAILED);
     });
 });
+
+describe('#action', () => {
+    it('runs action when ticked', () => {
+        let tree = btree.parse(`[a]`);
+        expect(tree.root.kind).to.be.equal(btree.ACTION);
+        // when
+        let activatedAction = null;
+        tree.onActionActivation(actionNode => activatedAction = actionNode);
+        tree.root.tick();
+        expect(tree.root.status()).equal(btree.RUNNING);
+        expect(tree.root.active).equal(true);
+        expect(activatedAction).equal(tree.root);
+    });
+});


### PR DESCRIPTION
- unified error handing to using `null` when no-error …
- action activation callback
- tree action activation callback
- sample of programmatic usage in README.md
- automatic testing of all code samples in README.md
- unified loading from JSON, parsing from text and programmatic creation
- optional type checking via `tsc --noEmit`
- tree viz generalized with configurable host HTML element